### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Hacklee\PRedisServiceProvider::class
 - 在app.php的aliases节点下增加以下代码
 
 ```
-'PRedis' => Hacklee\PRedisFacde::class
+'PRedis' => Hacklee\PRedisFacade::class
 ```
 或
 ```
-'PRedis' => 'Hacklee\PRedisFacde'
+'PRedis' => 'Hacklee\PRedisFacade'
 ```
 
 ### 使用示例

--- a/src/PRedisFacade.php
+++ b/src/PRedisFacade.php
@@ -4,7 +4,7 @@ namespace Hacklee;
 
 use Illuminate\Support\Facades\Facade;
 
-class PRedisFacde extends Facade
+class PRedisFacade extends Facade
 {
 	/**
 	 * Get the registered name of the component.


### PR DESCRIPTION
To keep consistency with other service providers and packages, fixing the 'Facde' typo to 'Facade'
